### PR TITLE
Upgrade to pydantic v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 itsdangerous==2.1.2
-pydantic==1.10.2
+pydantic==2.3.0
 requests_oauthlib==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-requirements = ["itsdangerous~=2.1.2", "pydantic~=1.10.2", "requests_oauthlib~=1.3.1"]
+requirements = ["itsdangerous~=2.1.2", "pydantic~=2.3.0", "requests_oauthlib~=1.3.1"]
 
 setuptools.setup(
     name="osm-login-python",


### PR DESCRIPTION
- Pydantic v1 --> v2 was a major breaking change.
- Luckily the usage of Pydantic in this package is not affected.
- More recent versions of FastAPI require Pydantic v2, so this upgrade would be useful to dependency locking.

As this is a breaking change, incrementing to `1.0.0` would make sense, but `0.1.0` would also work.

As we use this in FMTM, should we consider migrating to be under hotosm/osm-login-python?
@kshitijrajsharma @rsavoye