### PR TITLE
Add pep631 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "BSD-3-Clause"}
 requires-python = ">=3.9"
 dependencies = [
     "itsdangerous==2.1.2",
-    "pydantic==2.3.0",
+    "pydantic>=2.0.1",
     "requests-oauthlib==1.3.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ description = "Use OSM Token exchange with OAuth2.0 for python projects"
 readme = "README.md"
 authors = [{name = "Kshitij Raj Sharma", email = "skshitizraj@gmail.com"}]
 license = {text = "BSD-3-Clause"}
+requires-python = ">=3.9"
+dependencies = [
+    "itsdangerous==2.1.2",
+    "pydantic==2.3.0",
+    "requests-oauthlib==1.3.1",
+]
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-itsdangerous==2.1.2
-pydantic==2.3.0
-requests_oauthlib==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-requirements = ["itsdangerous~=2.1.2", "pydantic~=2.3.0", "requests_oauthlib~=1.3.1"]
+requirements = ["itsdangerous~=2.1.2", "pydantic>=2.0.1", "requests_oauthlib~=1.3.1"]
 
 setuptools.setup(
     name="osm-login-python",


### PR DESCRIPTION
- Currently requirements are specified in requirements.txt and also setup.py for a standard pip install.
- This works as expected, all dependencies are bundled.
- For other install tools that use the more modern pep631 spec, the dependencies are not bundled.

This PR will fix dependency bundling in FMTM.
We use PDM to manage dependencies, which I believe uses pep517 to build wheels, so dependencies are currently not being included.

**Edit** I also updated the pin for Pydantic. I don't think we should lock to a specific version, as Pydantic usage is minimal & will likely not break this package in future. We should have flexility in the lock to allow for higher pydantic versions in tools that rely on this (e.g. FMTM).